### PR TITLE
Remove trailing slash in neovim submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "neovim"]
 	path = neovim
-	url = https://github.com/neovim/neovim/
+	url = https://github.com/neovim/neovim
 	branch = master


### PR DESCRIPTION
This prevents an error where git does not find that repository.

<-- Your PR text here -->

**Licensing**: The code contributed to nvim-rs is licensed under the MIT or
Apache license as given in the project root directory.
